### PR TITLE
Fix isWeChatTweakInstalled

### DIFF
--- a/src/util/isWeChatInstalled.tsx
+++ b/src/util/isWeChatInstalled.tsx
@@ -2,7 +2,9 @@ import * as fs from "fs"
 
 export const isWeChatInstalled = (): boolean => {
   try {
-    return fs.existsSync("/Applications/WeChat.app" || "/Applications/微信.app")
+    return ["/Applications/WeChat.app", "/Applications/微信.app"].some(
+      fs.existsSync
+    )
   } catch (e) {
     console.error(String(e))
     return false

--- a/src/util/isWeChatTweakInstalled.tsx
+++ b/src/util/isWeChatTweakInstalled.tsx
@@ -2,14 +2,14 @@ import * as fs from "fs"
 
 export const isWeChatTweakInstalled = (): boolean => {
   try {
-    return fs.existsSync(
-      "/usr/local/bin/wechattweak-cli" ||
-        "/usr/local/Cellar/wechattweak-cli" ||
-        "/usr/local/opt/wechattweak-cli" ||
-        "/usr/local/bin/wechattweak-cli" ||
-        "/opt/homebrew/bin/wechattweak-cli" ||
-        "/usr/local/bin/wechattweak-cli"
-    )
+    return [
+      "/usr/local/bin/wechattweak-cli",
+      "/usr/local/Cellar/wechattweak-cli",
+      "/usr/local/opt/wechattweak-cli",
+      "/usr/local/bin/wechattweak-cli",
+      "/opt/homebrew/bin/wechattweak-cli",
+      "/usr/local/bin/wechattweak-cli"
+    ].some(fs.existsSync)
   } catch (e) {
     console.error(String(e))
     return false


### PR DESCRIPTION
Fix isWeChatTweakInstalled function, previous version only tested the first path.
From:
```js
fs.existsSync(
      "/usr/local/bin/wechattweak-cli" ||
        "/usr/local/Cellar/wechattweak-cli" ||
        "/usr/local/opt/wechattweak-cli" ||
        "/usr/local/bin/wechattweak-cli" ||
        "/opt/homebrew/bin/wechattweak-cli" ||
        "/usr/local/bin/wechattweak-cli"
    )
```
to:
```js
[
      "/usr/local/bin/wechattweak-cli",
      "/usr/local/Cellar/wechattweak-cli",
      "/usr/local/opt/wechattweak-cli",
      "/usr/local/bin/wechattweak-cli",
      "/opt/homebrew/bin/wechattweak-cli",
      "/usr/local/bin/wechattweak-cli"
    ].some(fs.existsSync)
```