### PR TITLE
fix: homebrew not installed because of no env viriable PATH.

### DIFF
--- a/src/manageTweak.tsx
+++ b/src/manageTweak.tsx
@@ -21,7 +21,21 @@ function ManageTweak() {
     isWeChatServiceRunning: false,
   });
 
+  const patchPath = () => {
+    if (!process.env.PATH || process.env.PATH === "") {
+      process.env.PATH = [
+        "/opt/homebrew/bin", // Apple Silicon Mac 常见
+        "/usr/local/bin", // Intel Mac 常见
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin",
+      ].join(":");
+    }
+  };
+
   useEffect(() => {
+    patchPath();
     checkStatus();
   }, []);
 


### PR DESCRIPTION
作者你好：

我在使用该插件时发现，即使我通过官网安装了homebrew，但插件仍然每次提示我没有安装homebrew。

![image](https://github.com/user-attachments/assets/f4e9ffcf-b8f8-4331-8cb8-7a0e8213aaf6)

本地调试后，我粗浅的理解是：raycast插件的启动环境与直接在终端运行node程序的环境不同，后者通过终端，可以继承我zsh配置中的PATH内容，但前者不会（AI的解释：“前者是由 macOS 的 launchd 直接启动的，它不会执行 shell 配置脚本，所以 PATH 等变量往往不完整。“）。

在代码中，我尝试直接添加process.env.PATH，这之后在我本地运行良好。希望我的代码符合规范和你的预期，如有不妥请多指教。

最后感谢你制作了这款优秀的插件❤️。